### PR TITLE
Use npm install rather than npm ci

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -44,7 +44,7 @@ jobs:
         restore-keys: node-dependencies-
 
     - name: Install Node dependencies
-      run: npm ci
+      run: npm install
 
     - name: Build
       run: npm run build


### PR DESCRIPTION
I _think_ the switch to npm ci is causing some issues with how a babel/runtime dependency is being handled in MacOS vs Ubuntu. I'm seeing build changes from this workflow that I can't reproduce in my local environment at all: once with extensive gymnastics and then never again.

I'm going to take the chance that `npm install` provides a way for OS dependent versions to be installed in this massive web of crap I don't want to understand.