### PR TITLE
Specify protocol 31 in rsync connections

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
       uses: easingthemes/ssh-deploy@v5.1.1
       env:
           SSH_PRIVATE_KEY: ${{ secrets.REMOTE_SSH_PRIVATE_KEY }}
-          ARGS: "-rltgoDzvO --include-from=.deploy_include --exclude-from=.deploy_ignore --delete"
+          ARGS: "--protocol=31 -rltgoDzvO --include-from=.deploy_include --exclude-from=.deploy_ignore --delete"
           SOURCE: "./"
           REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
           REMOTE_USER: ${{ secrets.REMOTE_USER }}


### PR DESCRIPTION
Kinsta uses rsync 3.2.7 with protocol 31
Pressable uses rsync 3.2.7 with protocol 32
WPE uses rsync 3.2.7 with protocol 31

This may apparently solve an issue with deployments on Pressable?